### PR TITLE
Multiple vhosts

### DIFF
--- a/rabbitmq.conf-dist
+++ b/rabbitmq.conf-dist
@@ -12,7 +12,7 @@
        #PmapBin
        #PidFile
        #Verbose boolean
-       #Vhost string
+       #Vhost one two three
     </Module>
 </Plugin>
 


### PR DESCRIPTION
Allow multiple virtual hosts to be passed in, script will loop through and collect metrics for each.

This also only collects metrics for DURABLE queues, may not be desirable in all cases, could be made a configuration option.
