### PR TITLE
Http api

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 This is a rudimentary RabbitMQ plugin for Collectd.  It is written in Python, and thus requires the use of the Python plugin for Collectd.
 
-It will accept 7 options from the Collectd plugin configuration :
+It will accept 8 options from the Collectd plugin configuration :
 
     Locations of binaries:
     RmqcBin = /usr/sbin/rabbitmqctl
@@ -10,7 +10,8 @@ It will accept 7 options from the Collectd plugin configuration :
     or API information:
     Api = http://localhost:15672/api/queues
     Vhost = /
-    UserPass= guest:guest
+    User = guest
+    Pass = guest
 
     Logging:
     Verbose = False
@@ -26,6 +27,16 @@ It will attempt to gather the following information:
     memory mapped
     memory writeable/private (used)
     memory shared
+
+There is also a dependency of python library 'requests', which is supposed
+to be installed before using the plugin.
+To install 'requests' libraray:
+Rhel:
+yum install python-requests
+Debian:
+apt-get install python-requests
+Or if you have pip installed:
+pip install requests
 
 The script is licensed using the Apache License, Version 2.0 :
 http://www.apache.org/licenses/LICENSE-2.0

--- a/README
+++ b/README
@@ -1,11 +1,16 @@
 This is a rudimentary RabbitMQ plugin for Collectd.  It is written in Python, and thus requires the use of the Python plugin for Collectd.
 
-It will accept 4 options from the Collectd plugin configuration :
+It will accept 7 options from the Collectd plugin configuration :
 
     Locations of binaries:
     RmqcBin = /usr/sbin/rabbitmqctl
     PmapBin = /usr/bin/pmap
     PidFile = /var/run/rabbitmq/pid
+    
+    or API information:
+    Api = http://localhost:15672/api/queues
+    Vhost = /
+    UserPass= guest:guest
 
     Logging:
     Verbose = False

--- a/rabbitmq.conf-dist
+++ b/rabbitmq.conf-dist
@@ -8,6 +8,8 @@
     Import "rabbitmq_info"
     <Module rabbitmq_info>
        Vhost "/"
+       Api "http://localhost:15672"
+       UserPass "guest:guest"
        #RmqcBin
        #PmapBin
        #PidFile

--- a/rabbitmq.conf-dist
+++ b/rabbitmq.conf-dist
@@ -8,8 +8,9 @@
     Import "rabbitmq_info"
     <Module rabbitmq_info>
        Vhost "/"
-       Api "http://localhost:15672"
-       UserPass "guest:guest"
+       Api "http://localhost:15672/api/queues"
+       User "guest"
+       Pass "guest"
        #RmqcBin
        #PmapBin
        #PidFile

--- a/rabbitmq_info.py
+++ b/rabbitmq_info.py
@@ -58,7 +58,7 @@ def get_stats():
 #            'list_queues', 'name', 'messages', 'memory', 'consumers'],
 #            shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     except:
-        logger('err', 'Failed to run curl %s' % RABBITMQ_API)
+        logger('err', 'Failed to run curl %s/%s' % (RABBITMQ_API, VHOST))
         return None
 
 #    for line in p.stdout.readlines():
@@ -80,7 +80,7 @@ def get_stats():
     try:
         resp=json.loads(script_response[7])
     except:
-        logger('err', 'No result found for this queue')
+        logger('err', 'No result found for this vhost')
         return None
     for i in range(0, len(resp)-1):
         stats['ctl_messages'] += resp[i]['messages']


### PR DESCRIPTION
Use http api of rabbitmq server to collect queue statistics data to avoid issue said here:
https://github.com/phrawzty/rabbitmq-collectd-plugin/issues/5
In this issue, rabbitmqctl failed to be spawn inside collectd python plugin even though the python script can be run without problem in system python environment. Although the root cause has not been identified yet, http api seems to be a clean way to collect the data.
